### PR TITLE
Fix bug with file detect

### DIFF
--- a/ftdetect/hack.vim
+++ b/ftdetect/hack.vim
@@ -14,6 +14,6 @@
 au BufRead,BufNewFile *.hhi setl filetype=php
 
 au BufRead,BufNewFile *.hh
-  \ if getline(1) =~ '^<?hh'
-  \   setl filetype=php
+  \ if getline(1) =~ '^<?hh' |
+  \   setl filetype=php |
   \ endif


### PR DESCRIPTION
Prior to this fix, upon opening a file matching *.hh the following error would appear:

```
Error detected while processing BufRead Auto commands for "*.hh":
E15: Invalid expression: getline(1) =~ '^<?hh'   setl filetype=php endif
```
