### PR TITLE
typecheck .hh extension as well

### DIFF
--- a/plugin/hack.vim
+++ b/plugin/hack.vim
@@ -111,6 +111,7 @@ command! -nargs=1 HackFindRefs call hack#find_refs(<q-args>)
 
 au BufWritePost *.php if g:hack#enable | call hack#typecheck() | endif
 au BufWritePost *.hhi if g:hack#enable | call hack#typecheck() | endif
+au BufWritePost *.hh if g:hack#enable | call hack#typecheck() | endif
 
 
 " Keep quickfix window at an adjusted height.


### PR DESCRIPTION
Currently type check only runs on buffer save with .php & .hhi extensions.  This PR just adds the .hh extension to that list.
