### PR TITLE
updating deprecated option

### DIFF
--- a/plugin/hack.vim
+++ b/plugin/hack.vim
@@ -57,7 +57,7 @@ function! <SID>HackClientCall(suffix)
   " error.  We also concatenate with the empty string because otherwise
   " cgetexpr complains about not having a String argument, even though
   " type(hh_result) == 1.
-  let hh_result = system(g:hack#hh_client.' --from-vim '.a:suffix)[:-2].''
+  let hh_result = system(g:hack#hh_client.' --from vim --retries 1 --retry-if-init false '.a:suffix)[:-2].''
 
   let old_fmt = &errorformat
   let &errorformat = s:hack_errorformat


### PR DESCRIPTION
Running `hh_client check --help` will tell you that the `--from-vim` option is deprecated and suggests you the equivalent:
```
--from-vim               (deprecated) equivalent to --from vim --retries 0 --retry-if-init false
```

I'm not sure when this was deprecated so ideally this should only get merged after at least 2 minor versions so people using older versions of hack would still have vim-hack working.