### PR TITLE
Add hack formatting.

### DIFF
--- a/after/ftplugin/php.vim
+++ b/after/ftplugin/php.vim
@@ -25,7 +25,7 @@ if !exists('g:hack#hh_format') && executable('hh_format')
 endif
 
 if !exists('g:hack#root')
-  let g:hack#root = '~/www'
+  let g:hack#root = '.'
 endif
 
 " Require the hh_client executable.

--- a/after/ftplugin/php.vim
+++ b/after/ftplugin/php.vim
@@ -20,6 +20,14 @@ if !exists('g:hack#hh_client')
   let g:hack#hh_client = 'hh_client'
 endif
 
+if !exists('g:hack#hh_format') && executable('hh_format')
+  let g:hack#hh_format = 'hh_format'
+endif
+
+if !exists('g:hack#root')
+  let g:hack#root = '~/www'
+endif
+
 " Require the hh_client executable.
 if !executable(g:hack#hh_client)
   finish

--- a/plugin/hack.vim
+++ b/plugin/hack.vim
@@ -107,11 +107,34 @@ function! hack#toggle()
   endif
 endfunction
 
+function! hack#format(from, to)
+  if !executable(g:hack#hh_format)
+    echo 'g:hack#hh_format not executable'
+  endif
+
+  if &modified
+    echo 'Error[hack]: buffer has unsaved changes'
+    return
+  endif
+  let frombyte = line2byte(a:from)
+
+  let tobyte = line2byte(a:to) + strlen(getline(a:to))
+
+  execute a:from.','.a:to.' ! '.g:hack#hh_format.
+    \ ' --from '.frombyte.' --to '.tobyte.
+    \ ' --root '.g:hack#root.' '.expand('%:p')
+  let tmp = g:hack#enable
+  " Disable auto checking
+  let g:hack#enable = 0
+  silent write
+  let g:hack#enable = tmp
+endfunction
 
 " Commands and auto-typecheck.
 command! HackToggle call hack#toggle()
 command! HackMake   call hack#typecheck()
 command! HackType   call hack#get_type()
+command! -range=% HackFormat call hack#format(<line1>, <line2>)
 command! -nargs=1 HackFindRefs call hack#find_refs(<q-args>)
 
 au BufWritePost *.php if g:hack#enable | call hack#typecheck() | endif

--- a/plugin/hack.vim
+++ b/plugin/hack.vim
@@ -116,8 +116,8 @@ function! hack#format(from, to)
     echo 'Error[hack]: buffer has unsaved changes'
     return
   endif
-  let frombyte = line2byte(a:from)
 
+  let frombyte = line2byte(a:from)
   let tobyte = line2byte(a:to) + strlen(getline(a:to))
 
   execute a:from.','.a:to.' ! '.g:hack#hh_format.


### PR DESCRIPTION
This diff adds :HackFormat. A command that works on line range, by default on the whole file. The buffer needs to be non modified and it will be saved after formatting without issuing a hack check (so it's faster).