### PR TITLE
Add HackSearch, interface to hh_client --search

### DIFF
--- a/doc/hack.txt
+++ b/doc/hack.txt
@@ -112,6 +112,24 @@ The behavior of this functionality can be controlled by the configuration flags
 described above.
 
 -------------------------------------------------------------------------------
+                                      *HackSearch* *HackSearch!* *hack-search*
+
+Populate the quickfix window with a list of definitions of identifiers that
+matches the input.
+
+:HackSearch
+                        Search using the word under the cursor.
+
+:HackSearch!
+                        Search using the full function name ("Class::func").
+                        |:HackSearch| looks up the name using hh_client. If
+                        the full name could not be found, it falls back to
+                        using the word under the cursor.
+
+:HackSearch {word}
+                        Search using the given word.
+
+-------------------------------------------------------------------------------
                                               *HackFindRefs*  *hack-find-refs*
 
 The Hack server also keeps track of references to each defined function.  To

--- a/plugin/hack.vim
+++ b/plugin/hack.vim
@@ -60,16 +60,21 @@ function! s:JobExitHandler(job_id)
   call <SID>HackPopulateQuickfix(hh_result)
 endfunction
 
-" Call wrapper for hh_client.
-function! <SID>HackClientCall(extra_args)
-  " Invoke typechecker. If using neovim, then invoke it asynchronously with
-  " Neovim's job-control functionality.
-  let hh_command = [
+" Returns command line for calling hack.
+function! <SID>HackClientInvocation(extra_args)
+  return [
   \ g:hack#hh_client,
   \ '--from', 'vim',
   \ '--retries', '1',
   \ '--retry-if-init', 'false'
   \ ] + a:extra_args
+endfunction
+
+" Call wrapper for hh_client.
+function! <SID>HackClientCall(extra_args)
+  " Invoke typechecker. If using neovim, then invoke it asynchronously with
+  " Neovim's job-control functionality.
+  let hh_command = <SID>HackClientInvocation(a:extra_args)
 
   if s:nvim
     let s:stdout = []
@@ -106,6 +111,14 @@ function! <SID>HackPopulateQuickfix(hh_result)
   let &errorformat = old_fmt
 endfunction
 
+" Lookup the identifier under cursor.
+function! <SID>HackLookupCurrentIdentifier()
+  silent let result = system(
+  \ join(<SID>HackClientInvocation(['--identify-function', line('.').':'.col('.')])),
+  \ getline(1, '$'))
+  return substitute(result, '^\s*\(.\{-}\)\s*$', '\1', '') " strip ws
+endfunction
+
 " Main interface functions.
 function! hack#typecheck()
   call <SID>HackClientCall([])
@@ -113,6 +126,21 @@ endfunction
 
 function! hack#find_refs(fn)
   call <SID>HackClientCall(['--find-refs', a:fn])
+endfunction
+
+function! hack#search(full_lookup, name)
+  let name = a:name
+  if name == ''
+    " Look up full identifier.
+    if a:full_lookup
+      let name = <SID>HackLookupCurrentIdentifier()
+    endif
+    " Use current word.
+    if name == ''
+      let name = expand('<cword>')
+    endif
+  end
+  call <SID>HackClientCall(['--search', name])
 endfunction
 
 " Get the Hack type at the current cursor position.
@@ -163,6 +191,7 @@ command! HackMake   call hack#typecheck()
 command! HackType   call hack#get_type()
 command! -range=% HackFormat call hack#format(<line1>, <line2>)
 command! -nargs=1 HackFindRefs call hack#find_refs(<q-args>)
+command! -nargs=? -bang HackSearch call hack#search('<bang>' == '!', <q-args>)
 
 au BufWritePost *.php if g:hack#enable | call hack#typecheck() | endif
 au BufWritePost *.hhi if g:hack#enable | call hack#typecheck() | endif


### PR DESCRIPTION
Add a `:HackSearch` command which calls out to `hh_client --search` to look up definitions, and display results in the quickfix window. This command can be called with no arguments to use the word under cursor. It can also be called with `!` to do a lookup of the full name under cursor (using `hh_client --identify-function`).