### PR TITLE
Added "go to definition"

### DIFF
--- a/doc/hack.txt
+++ b/doc/hack.txt
@@ -61,6 +61,10 @@ The Hack typechecker plugin exposes the following functions:
                         expression under the cursor.
       +--aliased as :HackType
 
+  hack#goto_def().......Go to the definition of                |hack-goto-def|
+                        expression under the cursor.
+      +--aliased as :HackGotoDef
+
   hack#toggle().........Toggle whether or not the typechecker    |hack-toggle|
                         runs on a buffer when it's written.
       +--aliased as :HackToggle
@@ -159,6 +163,17 @@ will echo the line
 
 This is not restricted to explicitly typed properties, but works also for local
 variables and function returns.
+
+-------------------------------------------------------------------------------
+                                                *HackGotoDef*  *hack-goto-def*
+
+The Hack server can be queried for the definition of any expression in the
+program. To go to the definition of the expression under cursor, simply
+execute
+
+  :HackGotoDef
+
+This command requires Vim 8.0 or Neovim.
 
 -------------------------------------------------------------------------------
                                                    *HackToggle*  *hack-toggle*

--- a/plugin/hack.vim
+++ b/plugin/hack.vim
@@ -153,6 +153,29 @@ function! hack#get_type()
   echo output
 endfunction
 
+" Go to definition
+function! hack#goto_def()
+  if !has('nvim') && v:version < 800
+    echom 'Vim 8.0 or Neovim is required for this function.'
+    return
+  endif
+
+  let pos = line('.').':'.col('.')
+  let cmd = join(<SID>HackClientInvocation(['--json', '--ide-get-definition', pos]))
+  let stdin = join(getline(1,'$'), "\n")
+
+  let output = get(json_decode(system(cmd, stdin)), 0, {})
+  if !has_key(output, 'definition_pos')
+    return
+  endif
+
+  let pos = output.definition_pos
+  if !empty(pos.filename)
+    execute 'edit '.(pos.filename)
+  endif
+  call cursor(pos.line, pos.char_start)
+endfunction
+
 " Toggle auto-typecheck.
 function! hack#toggle()
   if g:hack#enable
@@ -189,6 +212,7 @@ endfunction
 command! HackToggle call hack#toggle()
 command! HackMake   call hack#typecheck()
 command! HackType   call hack#get_type()
+command! HackGotoDef call hack#goto_def()
 command! -range=% HackFormat call hack#format(<line1>, <line2>)
 command! -nargs=1 HackFindRefs call hack#find_refs(<q-args>)
 command! -nargs=? -bang HackSearch call hack#search('<bang>' == '!', <q-args>)


### PR DESCRIPTION
This commit adds "go to definition". It uses the same mechanism as Nuclide hyperclick (see https://github.com/facebook/nuclide/blob/master/pkg/nuclide-hack-rpc/lib/HackService.js#L266). Json parsing is done using the new json_decode introduced in both vim8 and neovim.