### PR TITLE
syntax: allow whitespace before a generic

### DIFF
--- a/after/syntax/php.vim
+++ b/after/syntax/php.vim
@@ -43,7 +43,7 @@ hi def link hackTypeDecl Structure
 
 " Hack generic types.
 syn region hackGenericType matchgroup=hackGenericType contained
-  \ start=+\w\+<+hs=e
+  \ start=+\w\+\s*<+hs=e
   \ end=+>+
   \ contains=phpType,phpClasses,phpInterfaces,hackGenericType
 


### PR DESCRIPTION
Hack allows for whitespace between an identifier and a generic type. For
instance, the following are the same:

```
function getFooBar<T>(MyGeneric<T> $foo): string {
function getFooBar<T>(MyGeneric <T> $foo): string {
```

Without this change, the above would cause the ` <T>` to be interpreted
as XHP, and would mess up highlighting for the rest of the file.