### PR TITLE
Fix "Using List as String" error

### DIFF
--- a/plugin/hack.vim
+++ b/plugin/hack.vim
@@ -115,7 +115,7 @@ endfunction
 function! <SID>HackLookupCurrentIdentifier()
   silent let result = system(
   \ join(<SID>HackClientInvocation(['--identify-function', line('.').':'.col('.')])),
-  \ getline(1, '$'))
+  \ join(getline(1, '$')))
   return substitute(result, '^\s*\(.\{-}\)\s*$', '\1', '') " strip ws
 endfunction
 


### PR DESCRIPTION
`getline()` returns a list, but we're passing this list to `system()`, which accepts the content of a file as a string.  Joining the list here kills the error and makes this work.