### PR TITLE
Fix word based search

### DIFF
--- a/plugin/hack.vim
+++ b/plugin/hack.vim
@@ -137,7 +137,7 @@ function! hack#search(full_lookup, name)
     endif
     " Use current word.
     if name == ''
-      let name = expand('<cword>')
+      let name = substitute(expand('<cword>'), '[^A-Za-z0-9_$].*$', '', '')
     endif
   end
   call <SID>HackClientCall(['--search', name])


### PR DESCRIPTION
This doesn't work for things like methods, because it includes all the decorator stuff vim doesn't recognise as a delimiter.  Stripping that stuff fixes this.