### PR TITLE
Make event handlers to accept 3 arguments

### DIFF
--- a/plugin/hack.vim
+++ b/plugin/hack.vim
@@ -51,11 +51,11 @@ let s:hack_errorformat =
   \  '%EFile "%f"\, line %l\, characters %c-%.%#,%Z%m,'
   \ .'Error: %m,'
 
-function! s:JobStdoutHandler(job_id, data)
+function! s:JobStdoutHandler(job_id, data, event)
   let s:stdout = s:stdout + a:data
 endfunction
 
-function! s:JobExitHandler(job_id)
+function! s:JobExitHandler(job_id, data, event)
   let hh_result = join(s:stdout, "\n")
   call <SID>HackPopulateQuickfix(hh_result)
 endfunction


### PR DESCRIPTION
Running `:HackMake` in neovim triggers `E118: Too many arguments for function: <SNR>24_JobExitHandler`. This is because neovim requires all event handlers to accept 3 arguments: https://github.com/neovim/neovim/commit/0f681c80e1e9c9060394365dae12f8ebd5736176.

This change fixes https://github.com/hhvm/vim-hack/issues/32. 