### PR TITLE
[neovim] Prevent quickfix window from stealing focus when it opens

### DIFF
--- a/plugin/hack.vim
+++ b/plugin/hack.vim
@@ -102,10 +102,15 @@ function! <SID>HackPopulateQuickfix(hh_result)
     cgetexpr a:hh_result
   endif
 
+  let l:winnr = winnr()
   if g:hack#autoclose
     botright cwindow
   else
     botright copen
+  endif
+
+  if (s:nvim && l:winnr != winnr())
+    exe l:winnr . "wincmd w"
   endif
 
   let &errorformat = old_fmt


### PR DESCRIPTION
Fixes #36 

Tested with only vim-hack installed and an empty rcfile. No change to the vim behavior and it fixes the unexpected behavior in neovim.