### PR TITLE
Don't require (or understand) leading markup or <?hh in .hack files

### DIFF
--- a/after/syntax/hack.vim
+++ b/after/syntax/hack.vim
@@ -1,0 +1,3 @@
+" Syntax files for .hack files
+syn include @php <sfile>:p:h/php.vim
+syn region hackRegion start="\%^" end="\%$" contains=@phpClTop

--- a/after/syntax/php.vim
+++ b/after/syntax/php.vim
@@ -9,6 +9,7 @@
 " This source code is licensed under the MIT license found in the
 " LICENSE file in the toplevel directory of this source tree.
 
+source $VIMRUNTIME/syntax/php.vim
 
 " We clear templatizable PHP keywords because keyword always takes precedence
 " over match and region.

--- a/ftdetect/hack.vim
+++ b/ftdetect/hack.vim
@@ -8,8 +8,12 @@
 "
 " This source code is licensed under the MIT license found in the
 " LICENSE file in the top level directory of this source tree.
+"
+au BufRead,BufNewFile *.hack
+  \ setl filetype=hack |
+  \ setl syntax=hack
 
-au BufRead,BufNewFile *.hhi,*.hack,*.hck
+au BufRead,BufNewFile *.hhi,*.hck
   \ setl filetype=hack |
   \ setl syntax=php
 


### PR DESCRIPTION
These two files are equivalent:

# foo.php

```Hack
<?hh // strict

function foo(): void {
}
```

# foo.hack

```Hack
function foo(): void {
}
```