### PR TITLE
Smarter indentation support for attribute tags

### DIFF
--- a/after/indent/hack.vim
+++ b/after/indent/hack.vim
@@ -19,7 +19,7 @@ setlocal indentexpr=GetHackIndent()
 function! GetHackIndent()
   let php_indent = GetPhpIndent()
 
-  if getline(v:lnum-1) =~? '<<.*>>$'
+  if getline(v:lnum-1) =~? '^\s*<<.*>>$'
     return php_indent - shiftwidth()
   end
 

--- a/after/indent/hack.vim
+++ b/after/indent/hack.vim
@@ -1,0 +1,27 @@
+" Vim indentation file
+" Language:     Hack (PHP)
+" Maintainer:   Joe Palazzolo <jpalazzolo@fb.com>
+" URL:          https://github.com/hhvm/vim-hack
+" Last Change:  May 31, 2019
+"
+" Copyright: (c) 2014, Facebook Inc.  All rights reserved.
+"
+" This source code is licensed under the MIT license found in the
+" LICENSE file in the toplevel directory of this source tree.
+
+if exists("b:indent_loaded")
+  finish
+end
+let b:indent_loaded = 1
+
+setlocal indentexpr=GetHackIndent()
+
+function! GetHackIndent()
+  let php_indent = GetPhpIndent()
+
+  if getline(v:lnum-1) =~? '<<.*>>$'
+    return php_indent - shiftwidth()
+  end
+
+  return php_indent
+endfunction


### PR DESCRIPTION
The default PHP indentation doesn't work that well with hack attributes. It adds another level of indentation after attribute lines.

Before:
```
<<__Override>>
  public function foo() {}
```

After:
```
<<__Override>>
public function foo() {}
```

The fix is to check the usual PHP indentation level and simply subtract one when the previous line has something that looked like an attribute.