### PR TITLE
Don't highlight backticks as strings

### DIFF
--- a/after/syntax/php.vim
+++ b/after/syntax/php.vim
@@ -33,6 +33,9 @@ syn keyword phpType bool[ean] int[eger] real double float string object null con
 syn keyword phpType void mixed tuple num stringish this resource contained
 syn match phpType +^array$+ contained
 
+" Backticks are not legal string delimiters in Hack.
+syn clear phpBacktick
+
 " Hack type declarations.
 syn keyword hackTypeDecl type newtype shape contained
 


### PR DESCRIPTION
This is no longer supported in Hack, and will be used for expression
trees in future.

![Screenshot 2021-01-20 at 18 09 23](https://user-images.githubusercontent.com/70800/105270672-0802ad00-5b4b-11eb-9674-c8b1c2af1f82.png)

cc @fredemmott 